### PR TITLE
Optional use of pre created signature key

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ interface GetSignedUrlOptions {
   date?: Date                                   // forced creation date, for testing
   endpoint?: string                             // custom endpoint, default s3.amazonaws.com
   usePathRequestStyle?: boolean                 // use s3.amazonaws.com/<bucket>/<key> request style
+  signatureKey?: string                         // optional pre-generated signature created with getPreSignatureKey()
 }
 ```
 

--- a/mod.ts
+++ b/mod.ts
@@ -15,6 +15,7 @@ export interface GetSignedUrlOptions {
   date?: Date,
   endpoint?: string,
   usePathRequestStyle?: boolean,
+  signatureKey?: string,
 }
 
 function sha256(data: string): string {
@@ -58,6 +59,7 @@ function parseOptions(provided: GetSignedUrlOptions): Required<GetSignedUrlOptio
       endpoint: 's3.amazonaws.com',
       queryParams: {},
       usePathRequestStyle: false,
+      signatureKey: '',
     },
     ...provided,
   }
@@ -121,12 +123,12 @@ export function getPreSignatureKey(options: GetSignedUrlOptions): any {
   return getSignatureKey(parsedOptions);
 }
 
-export function getSignedUrl(options: GetSignedUrlOptions, preSignatureKey?: string): string {
+export function getSignedUrl(options: GetSignedUrlOptions): string {
   const parsedOptions = parseOptions(options)
   const queryParameters = getQueryParameters(parsedOptions)
   const canonicalRequest = getCanonicalRequest(parsedOptions, queryParameters)
   const signaturePayload = getSignaturePayload(parsedOptions, canonicalRequest)
-  const signatureKey = preSignatureKey || getSignatureKey(parsedOptions)
+  const signatureKey = parsedOptions.signatureKey || getSignatureKey(parsedOptions)
   const signature = hmacSha256Hex(signatureKey, signaturePayload)
   const url = getUrl(parsedOptions, queryParameters, signature)
 

--- a/mod.ts
+++ b/mod.ts
@@ -2,7 +2,7 @@ import { Sha256, HmacSha256 } from 'https://deno.land/std@0.160.0/hash/sha256.ts
 
 const NEWLINE = '\n'
 
-interface GetSignedUrlOptions {
+export interface GetSignedUrlOptions {
   bucket: string
   key: string
   accessKeyId: string

--- a/mod.ts
+++ b/mod.ts
@@ -116,12 +116,17 @@ function getUrl(options: Required<GetSignedUrlOptions>, queryParameters: URLSear
   return `https://${getHost(options)}${getPath(options)}?${new URLSearchParams(queryParameters).toString()}`
 }
 
-export function getSignedUrl(options: GetSignedUrlOptions): string {
+export function getPreSignatureKey(options: GetSignedUrlOptions): any {
+  const parsedOptions = parseOptions(options);
+  return getSignatureKey(parsedOptions);
+}
+
+export function getSignedUrl(options: GetSignedUrlOptions, preSignatureKey?: string): string {
   const parsedOptions = parseOptions(options)
   const queryParameters = getQueryParameters(parsedOptions)
   const canonicalRequest = getCanonicalRequest(parsedOptions, queryParameters)
   const signaturePayload = getSignaturePayload(parsedOptions, canonicalRequest)
-  const signatureKey = getSignatureKey(parsedOptions)
+  const signatureKey = preSignatureKey || getSignatureKey(parsedOptions)
   const signature = hmacSha256Hex(signatureKey, signaturePayload)
   const url = getUrl(parsedOptions, queryParameters, signature)
 

--- a/test.ts
+++ b/test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
 } from 'https://deno.land/std@0.103.0/testing/asserts.ts'
-import { getSignedUrl } from './mod.ts'
+import { getPreSignatureKey, getSignedUrl } from './mod.ts'
 
 const date = new Date('Fri, 24 May 2013 00:00:00 GMT')
 
@@ -47,3 +47,15 @@ Deno.test('creates a presigned URL with a session token', () => {
     ].join('')
   )
 })
+
+Deno.test('creates a pre signature key', () => {
+  const signature = getPreSignatureKey(baseTestOptions);
+  assertEquals(signature.byteLength, 32);
+})
+
+Deno.test('generate two urls and compare', () => {
+  const signature = getPreSignatureKey(baseTestOptions);
+  const preSignatureKeyUrl = getSignedUrl(baseTestOptions, signature);
+  const url = getSignedUrl(baseTestOptions);
+  assertEquals(preSignatureKeyUrl, url);
+});

--- a/test.ts
+++ b/test.ts
@@ -54,8 +54,10 @@ Deno.test('creates a pre signature key', () => {
 })
 
 Deno.test('generate two urls and compare', () => {
-  const signature = getPreSignatureKey(baseTestOptions);
-  const preSignatureKeyUrl = getSignedUrl(baseTestOptions, signature);
+  const signatureKey = getPreSignatureKey(baseTestOptions);
+  const baseTestOptionsWithSignature = { ...baseTestOptions, signatureKey: signatureKey }
+  const preSignatureKeyUrl = getSignedUrl(baseTestOptionsWithSignature);
+
   const url = getSignedUrl(baseTestOptions);
   assertEquals(preSignatureKeyUrl, url);
 });

--- a/test.ts
+++ b/test.ts
@@ -1,11 +1,11 @@
 import {
   assertEquals,
 } from 'https://deno.land/std@0.103.0/testing/asserts.ts'
-import { getPreSignatureKey, getSignedUrl } from './mod.ts'
+import { getPreSignatureKey, getSignedUrl, GetSignedUrlOptions } from './mod.ts'
 
 const date = new Date('Fri, 24 May 2013 00:00:00 GMT')
 
-const baseTestOptions = {
+const baseTestOptions: GetSignedUrlOptions = {
   bucket: 'examplebucket',
   key: '/test.txt',
   region: 'us-east-1',


### PR DESCRIPTION
Generation of the signature key is the most expensive part of this library.
This approach is necessary for generation of hundreds or even thousands of URLs.
I'm using this to deliver HLS video from CloudFront R2, we have videos with 5+ hours and thousands of fragments that have to be signed individually.