### PR TITLE
feat: option to specify http or https

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ interface GetSignedUrlOptions {
   expiresIn?: number                            // seconds, default 86400 (24 hours)
   date?: Date                                   // forced creation date, for testing
   endpoint?: string                             // custom endpoint, default s3.amazonaws.com
+  protocol?: string                             // 'http' or 'https' for endpoint, default 'https'
   usePathRequestStyle?: boolean                 // use s3.amazonaws.com/<bucket>/<key> request style
   signatureKey?: string                         // optional pre-generated signature created with getSignatureKey()
 }

--- a/mod.ts
+++ b/mod.ts
@@ -10,6 +10,7 @@ const DEFAULT_OPTIONS: OptionsWithDefaults = {
   date: new Date(),
   endpoint: 's3.amazonaws.com',
   usePathRequestStyle: false,
+  protocol: 'https'
 }
 
 interface OptionsWithDefaults {
@@ -20,6 +21,7 @@ interface OptionsWithDefaults {
   date: Date,
   endpoint: string,
   usePathRequestStyle: boolean,
+  protocol: string,
 }
 
 interface GetSignedUrlOptions extends Partial<OptionsWithDefaults> {
@@ -117,7 +119,7 @@ export function getSignatureKey(options: GetSignatureKeyOptions): ArrayBuffer {
 function getUrl(options: ParsedOptions, queryParameters: URLSearchParams, signature: string): string {
   queryParameters.set('X-Amz-Signature', signature)
 
-  return `https://${getHost(options)}${getPath(options)}?${new URLSearchParams(queryParameters).toString()}`
+  return `${options.protocol}://${getHost(options)}${getPath(options)}?${new URLSearchParams(queryParameters).toString()}`
 }
 
 export function getSignedUrl(providedOptions: GetSignedUrlOptions): string {


### PR DESCRIPTION
I've been doing some local development with [MinIO](https://min.io/), a self-hosted S3-compatible object store. However, I don't have HTTPS on my local machine so I need it to work with HTTP. Fortunately, I was able to make this tweak and it works fine. Still defaults to `https`.